### PR TITLE
Change description to be constant with the op codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Protobuf files for Nokia SR Linux NDK
+
 This branch contains source `.proto` files that define SR Linux NDK services.
 
 The NDK services generated documentation is [provided within this repository](https://rawcdn.githack.com/nokia/srlinux-ndk-protobufs/v0.1.0/doc/index.html).

--- a/doc/index.html
+++ b/doc/index.html
@@ -578,7 +578,7 @@ SPDX-License-Identifier: BSD-3-Clause -->
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -669,7 +669,7 @@ SPDX-License-Identifier: BSD-3-Clause -->
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as session create, delete, or update </p></td>
+                        <td><p>Operation such as session create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -1255,7 +1255,7 @@ Global if id for ipv6 link local session, otherwise 0 </p></td>
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -1462,7 +1462,7 @@ Global if id for ipv6 link local session, otherwise 0 </p></td>
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -2140,7 +2140,7 @@ Global if id for ipv6 link local session, otherwise 0 </p></td>
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -2491,7 +2491,7 @@ Global if id for ipv6 link local session, otherwise 0 </p></td>
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>
@@ -2753,7 +2753,7 @@ Global if id for ipv6 link local session, otherwise 0 </p></td>
                         <td>op</td>
                         <td><a href="#srlinux.sdk.SdkMgrOperation">SdkMgrOperation</a></td>
                         <td></td>
-                        <td><p>Operation such as create, delete, or update </p></td>
+                        <td><p>Operation such as create, change, or delete </p></td>
                       </tr>
                     
                       <tr>

--- a/ndk/appid_service.proto
+++ b/ndk/appid_service.proto
@@ -43,7 +43,7 @@ message AppIdentData
  */
 message AppIdentNotification
 {
-    SdkMgrOperation op = 1;  // Operation such as create, delete, or update
+    SdkMgrOperation op = 1;  // Operation such as create, change, or delete
     AppIdentKey  key   = 2;  // AppIdent key
     AppIdentData data  = 3;  // AppIdent data
 }

--- a/ndk/bfd_service.proto
+++ b/ndk/bfd_service.proto
@@ -92,7 +92,7 @@ message BfdmgrGeneralSessionDataPb
  */
 message BfdSessionNotification
 {
-    SdkMgrOperation op                                  = 1;  // Operation such as session create, delete, or update
+    SdkMgrOperation op                                  = 1;  // Operation such as session create, change, or delete
     BfdmgrGeneralSessionKeyPb  key                      = 2;  // Session key
     BfdmgrGeneralSessionDataPb data                     = 3;  // Session data
 }

--- a/ndk/interface_service.proto
+++ b/ndk/interface_service.proto
@@ -47,7 +47,7 @@ message InterfaceData
  */
 message InterfaceNotification
 {
-    SdkMgrOperation op                          = 1;  // Operation such as create, delete, or update
+    SdkMgrOperation op                          = 1;  // Operation such as create, change, or delete
     InterfaceKey  key                           = 2;  // Interface key
     InterfaceData data                          = 3;  // Interface data
 }

--- a/ndk/lldp_service.proto
+++ b/ndk/lldp_service.proto
@@ -73,7 +73,7 @@ message LldpNeighborDataPb
  */
 message LldpNeighborNotification
 {
-    SdkMgrOperation op                          = 1;  // Operation such as create, delete, or update
+    SdkMgrOperation op                          = 1;  // Operation such as create, change, or delete
     LldpNeighborKeyPb  key                      = 2;  // LLDP neighbor key
     LldpNeighborDataPb data                     = 3;  // LLDP neighbor data
 }

--- a/ndk/networkinstance_service.proto
+++ b/ndk/networkinstance_service.proto
@@ -49,7 +49,7 @@ message NetworkInstanceData
  */
 message NetworkInstanceNotification
 {
-    SdkMgrOperation op = 1;       // Operation such as create, delete, or update
+    SdkMgrOperation op = 1;       // Operation such as create, change, or delete
     NetworkInstanceKey  key = 2;  // Network key
     NetworkInstanceData data = 3; // Network data
 }

--- a/ndk/nexthop_group_service.proto
+++ b/ndk/nexthop_group_service.proto
@@ -137,7 +137,7 @@ message NextHopGroupSubscriptionRequest
  */
 message NextHopGroupNotification
 {
-    SdkMgrOperation op                          = 1;  // Operation such as create, delete, or update
+    SdkMgrOperation op                          = 1;  // Operation such as create, change, or delete
     uint64          key                         = 2;  // Next-hop group key
     NextHopGroup    data                        = 3;  // Next-hop group data
 }

--- a/ndk/route_service.proto
+++ b/ndk/route_service.proto
@@ -108,7 +108,7 @@ message IpRouteSubscriptionRequest
  */
 message IpRouteNotification
 {
-    SdkMgrOperation op                          = 1;  // Operation such as create, delete, or update
+    SdkMgrOperation op                          = 1;  // Operation such as create, change, or delete
     RouteKeyPb  key                             = 2;  // IP route key
     RoutePb data                                = 3;  // IP route data
 }


### PR DESCRIPTION
Every mention of the [sdkMgrOperation](https://rawcdn.githack.com/nokia/srlinux-ndk-protobufs/v0.1.0/doc/index.html#srlinux.sdk.SdkMgrOperation) object described it with create, delete, update. However the different operations are create, **change**, delete. This change prevents users from having to look into the operation update to see the constants linked with the operations. (order was changed to match the code numbers)